### PR TITLE
Make Ruby 2.4 compatible

### DIFF
--- a/lib/qsagi/standard_queue.rb
+++ b/lib/qsagi/standard_queue.rb
@@ -44,7 +44,7 @@ module Qsagi
 
     def pop(options = {})
       auto_ack = options.fetch(:auto_ack, true)
-      delivery_info, properties, message = @queue.pop(:ack => !auto_ack)
+      delivery_info, properties, message = @queue.pop(:manual_ack => !auto_ack)
 
       unless message.nil?
         _message_class.new(delivery_info, _serializer.deserialize(message))

--- a/lib/qsagi/version.rb
+++ b/lib/qsagi/version.rb
@@ -1,3 +1,3 @@
 module Qsagi
-  VERSION = "0.1.3"
+  VERSION = "0.2.0"
 end

--- a/qsagi.gemspec
+++ b/qsagi.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "bunny", "~> 1.2.0"
+  gem.add_dependency "bunny", "~> 2.9.2"
   gem.add_dependency "json", "~> 1.7"
 end


### PR DESCRIPTION
Bumps version of bunny and uses `:manual_ack` over deprecated `:ack`.

@agfor @pblesi