### PR TITLE
Loosen the json version requirement

### DIFF
--- a/lib/qsagi/version.rb
+++ b/lib/qsagi/version.rb
@@ -1,3 +1,3 @@
 module Qsagi
-  VERSION = "0.2.2"
+  VERSION = "0.2.3"
 end

--- a/qsagi.gemspec
+++ b/qsagi.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency "bunny", "~> 2.9.2"
-  gem.add_dependency "json", "~> 1.7"
+  gem.add_dependency "json", ">= 1.7"
 end


### PR DESCRIPTION
There is a CVE open for json versions prior to 2.3.0. Dependent applications cannot upgrade due to the existing restriction.